### PR TITLE
Fix AirPlay, add chapter progress mode, remove share

### DIFF
--- a/Sappho/Presentation/Detail/AudiobookDetailView.swift
+++ b/Sappho/Presentation/Detail/AudiobookDetailView.swift
@@ -173,15 +173,6 @@ struct AudiobookDetailView: View {
                         }
                     }
 
-                    moreMenuItem(
-                        icon: "square.and.arrow.up",
-                        title: "Share",
-                        subtitle: "Share this audiobook",
-                        color: .sapphoTextMuted
-                    ) {
-                        pendingSheet = .share
-                        showMoreMenu = false
-                    }
                 }
                 .padding(.horizontal, 16)
 

--- a/Sappho/Presentation/Home/MainView.swift
+++ b/Sappho/Presentation/Home/MainView.swift
@@ -275,14 +275,20 @@ struct MainView: View {
 // MARK: - Mini Player
 struct MiniPlayerView: View {
     @Environment(AudioPlayerService.self) private var audioPlayer
+    @AppStorage("showChapterProgress") private var showChapterProgress = false
     @Binding var showFullPlayer: Bool
 
     @State private var isSeeking = false
     @State private var seekPosition: Double = 0
 
     private var progressPercent: Double {
-        guard audioPlayer.duration > 0 else { return 0 }
         if isSeeking { return seekPosition }
+        if showChapterProgress, let chapter = audioPlayer.currentChapter {
+            let chapterDuration = chapter.duration ?? (audioPlayer.duration - chapter.startTime)
+            guard chapterDuration > 0 else { return 0 }
+            return max(0, min(1, (audioPlayer.position - chapter.startTime) / chapterDuration))
+        }
+        guard audioPlayer.duration > 0 else { return 0 }
         return audioPlayer.position / audioPlayer.duration
     }
 
@@ -326,7 +332,13 @@ struct MiniPlayerView: View {
                             }
                             .onEnded { value in
                                 let percent = max(0, min(1, value.location.x / geometry.size.width))
-                                let targetTime = percent * audioPlayer.duration
+                                let targetTime: Double
+                                if showChapterProgress, let chapter = audioPlayer.currentChapter {
+                                    let chapterDuration = chapter.duration ?? (audioPlayer.duration - chapter.startTime)
+                                    targetTime = chapter.startTime + percent * chapterDuration
+                                } else {
+                                    targetTime = percent * audioPlayer.duration
+                                }
                                 Task {
                                     await audioPlayer.seek(to: targetTime)
                                 }
@@ -360,7 +372,9 @@ struct MiniPlayerView: View {
                             MiniPlayerTimeDisplay(
                                 position: audioPlayer.position,
                                 duration: audioPlayer.duration,
-                                isPlaying: audioPlayer.isPlaying
+                                isPlaying: audioPlayer.isPlaying,
+                                showChapterProgress: showChapterProgress,
+                                currentChapter: audioPlayer.currentChapter
                             )
                         }
                     }
@@ -408,9 +422,25 @@ struct MiniPlayerTimeDisplay: View {
     let position: TimeInterval
     let duration: TimeInterval
     let isPlaying: Bool
+    var showChapterProgress: Bool = false
+    var currentChapter: Chapter? = nil
+
+    private var displayPosition: TimeInterval {
+        if showChapterProgress, let chapter = currentChapter {
+            return max(0, position - chapter.startTime)
+        }
+        return position
+    }
+
+    private var displayDuration: TimeInterval {
+        if showChapterProgress, let chapter = currentChapter {
+            return chapter.duration ?? (duration - chapter.startTime)
+        }
+        return duration
+    }
 
     var body: some View {
-        Text("\(formatTime(position)) / \(formatTime(duration))")
+        Text("\(formatTime(displayPosition)) / \(formatTime(displayDuration))")
             .font(.system(size: 10))
             .foregroundColor(isPlaying
                 ? Color.sapphoPrimaryLight

--- a/Sappho/Presentation/Player/PlayerView.swift
+++ b/Sappho/Presentation/Player/PlayerView.swift
@@ -8,6 +8,8 @@ struct PlayerView: View {
     @AppStorage("skipForwardSeconds") private var skipForwardSeconds = 30
     @AppStorage("skipBackwardSeconds") private var skipBackwardSeconds = 15
 
+    @AppStorage("showChapterProgress") private var showChapterProgress = false
+
     @State private var showSpeedPicker = false
     @State private var showSleepTimer = false
     @State private var showChapters = false
@@ -22,7 +24,7 @@ struct PlayerView: View {
                 Color.sapphoBackground.ignoresSafeArea()
 
             VStack(spacing: 0) {
-                // Drag handle + Header
+                // Drag handle + Header (outside drag gesture)
                 VStack(spacing: 0) {
                     Capsule()
                         .fill(Color.sapphoTextMuted.opacity(0.5))
@@ -36,6 +38,8 @@ struct PlayerView: View {
                             Image(systemName: "chevron.down")
                                 .font(.system(size: 20, weight: .semibold))
                                 .foregroundColor(.sapphoTextHigh)
+                                .frame(width: 44, height: 44)
+                                .contentShape(Rectangle())
                         }
                         .accessibilityLabel("Minimize player")
                         .accessibilityHint("Double tap to minimize to mini player")
@@ -51,12 +55,12 @@ struct PlayerView: View {
 
                         // AirPlay (matches Cast button position on Android)
                         AirPlayButton()
-                            .frame(width: 28, height: 28)
+                            .frame(width: 44, height: 44)
                             .accessibilityLabel("AirPlay")
                             .accessibilityHint("Double tap to choose audio output device")
                     }
                     .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
+                    .padding(.vertical, 8)
                 }
 
                 Spacer()
@@ -103,36 +107,75 @@ struct PlayerView: View {
 
                         // Progress Slider
                         VStack(spacing: 8) {
-                            Slider(
-                                value: Binding(
-                                    get: { isSeeking ? seekPosition : audioPlayer.position },
-                                    set: { newValue in
-                                        isSeeking = true
-                                        seekPosition = newValue
-                                    }
-                                ),
-                                in: 0...max(audioPlayer.duration, 1)
-                            ) { editing in
-                                if !editing {
-                                    Task {
-                                        await audioPlayer.seek(to: seekPosition)
-                                    }
-                                    isSeeking = false
-                                }
-                            }
-                            .tint(Color.sapphoPrimaryLight)
-                            .accessibilityLabel("Playback position")
-                            .accessibilityValue("\(formatTime(audioPlayer.position)) of \(formatTime(audioPlayer.duration))")
+                            if showChapterProgress, let chapter = audioPlayer.currentChapter {
+                                // Chapter-scoped slider
+                                let chapterStart = chapter.startTime
+                                let chapterDuration = max(chapter.duration ?? (audioPlayer.duration - chapterStart), 1)
+                                let chapterPosition = audioPlayer.position - chapterStart
 
-                            HStack {
-                                Text(formatTime(audioPlayer.position))
-                                    .accessibilityHidden(true)
-                                Spacer()
-                                Text("-" + formatTime(audioPlayer.duration - audioPlayer.position))
-                                    .accessibilityHidden(true)
+                                Slider(
+                                    value: Binding(
+                                        get: { isSeeking ? seekPosition : max(0, chapterPosition) },
+                                        set: { newValue in
+                                            isSeeking = true
+                                            seekPosition = newValue
+                                        }
+                                    ),
+                                    in: 0...chapterDuration
+                                ) { editing in
+                                    if !editing {
+                                        Task {
+                                            await audioPlayer.seek(to: chapterStart + seekPosition)
+                                        }
+                                        isSeeking = false
+                                    }
+                                }
+                                .tint(Color.sapphoPrimaryLight)
+                                .accessibilityLabel("Chapter position")
+                                .accessibilityValue("\(formatTime(max(0, chapterPosition))) of \(formatTime(chapterDuration))")
+
+                                HStack {
+                                    Text(formatTime(max(0, chapterPosition)))
+                                        .accessibilityHidden(true)
+                                    Spacer()
+                                    Text("-" + formatTime(max(0, chapterDuration - chapterPosition)))
+                                        .accessibilityHidden(true)
+                                }
+                                .font(.sapphoSmall)
+                                .foregroundColor(.sapphoTextMuted)
+                            } else {
+                                // Full book slider
+                                Slider(
+                                    value: Binding(
+                                        get: { isSeeking ? seekPosition : audioPlayer.position },
+                                        set: { newValue in
+                                            isSeeking = true
+                                            seekPosition = newValue
+                                        }
+                                    ),
+                                    in: 0...max(audioPlayer.duration, 1)
+                                ) { editing in
+                                    if !editing {
+                                        Task {
+                                            await audioPlayer.seek(to: seekPosition)
+                                        }
+                                        isSeeking = false
+                                    }
+                                }
+                                .tint(Color.sapphoPrimaryLight)
+                                .accessibilityLabel("Playback position")
+                                .accessibilityValue("\(formatTime(audioPlayer.position)) of \(formatTime(audioPlayer.duration))")
+
+                                HStack {
+                                    Text(formatTime(audioPlayer.position))
+                                        .accessibilityHidden(true)
+                                    Spacer()
+                                    Text("-" + formatTime(audioPlayer.duration - audioPlayer.position))
+                                        .accessibilityHidden(true)
+                                }
+                                .font(.sapphoSmall)
+                                .foregroundColor(.sapphoTextMuted)
                             }
-                            .font(.sapphoSmall)
-                            .foregroundColor(.sapphoTextMuted)
                         }
                         .padding(.horizontal, 20)
 
@@ -314,7 +357,6 @@ struct PlayerView: View {
 
                 Spacer()
             }
-            .contentShape(Rectangle())
             .offset(y: dragOffset)
             .gesture(
                 DragGesture()

--- a/Sappho/Presentation/Profile/ProfileView.swift
+++ b/Sappho/Presentation/Profile/ProfileView.swift
@@ -770,6 +770,7 @@ struct SettingsView: View {
     @AppStorage("skipForwardSeconds") private var skipForwardSeconds = 30
     @AppStorage("skipBackwardSeconds") private var skipBackwardSeconds = 15
     @AppStorage("rewindOnResume") private var rewindOnResume = 0
+    @AppStorage("showChapterProgress") private var showChapterProgress = false
 
     var body: some View {
         Form {
@@ -798,6 +799,7 @@ struct SettingsView: View {
                     Text("60 seconds").tag(60)
                 }
 
+                Toggle("Show Chapter Progress", isOn: $showChapterProgress)
             }
 
             // About

--- a/Sappho/Resources/Info.plist
+++ b/Sappho/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Sappho/Service/AudioPlayerService.swift
+++ b/Sappho/Service/AudioPlayerService.swift
@@ -45,7 +45,12 @@ class AudioPlayerService: NSObject {
 
     private func setupAudioSession() {
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio)
+            try AVAudioSession.sharedInstance().setCategory(
+                .playback,
+                mode: .spokenAudio,
+                policy: .longFormAudio,
+                options: []
+            )
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             print("Failed to configure audio session: \(error)")
@@ -94,6 +99,7 @@ class AudioPlayerService: NSObject {
 
         // Create player
         player = AVPlayer(playerItem: playerItem)
+        player?.allowsExternalPlayback = false // Force local decode + AirPlay audio routing (external playback fails with auth headers)
         player?.rate = playbackSpeed
 
         // Get duration
@@ -178,6 +184,7 @@ class AudioPlayerService: NSObject {
                 isObservingPlayerItem = true
 
                 player = AVPlayer(playerItem: playerItem)
+                player?.allowsExternalPlayback = false
                 player?.rate = playbackSpeed
 
                 if let durationSeconds = audiobook.duration {
@@ -565,17 +572,29 @@ class AudioPlayerService: NSObject {
         switch type {
         case .began:
             wasPlayingBeforeInterruption = isPlaying
-            pause()
+            player?.pause()
+            isPlaying = false
+            updateNowPlayingInfo()
         case .ended:
             let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
             let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
             if options.contains(.shouldResume) || wasPlayingBeforeInterruption {
-                resume()
+                do {
+                    try AVAudioSession.sharedInstance().setActive(true)
+                } catch {
+                    print("Failed to reactivate audio session after interruption: \(error)")
+                }
+                player?.play()
+                player?.rate = playbackSpeed
+                isPlaying = true
+                updateNowPlayingInfo()
             }
         @unknown default:
             break
         }
     }
+
+    private var wasPlayingBeforeRouteChange = false
 
     private func handleRouteChange(notification: Notification) {
         guard let userInfo = notification.userInfo,
@@ -584,9 +603,30 @@ class AudioPlayerService: NSObject {
             return
         }
 
-        // Pause when output device is disconnected (e.g. headphones unplugged)
-        if reason == .oldDeviceUnavailable {
-            pause()
+        switch reason {
+        case .oldDeviceUnavailable:
+            // Device disconnected (AirPlay off, headphones unplugged)
+            // Just pause the player, don't sync or save (avoid side effects during route change)
+            wasPlayingBeforeRouteChange = isPlaying
+            player?.pause()
+            isPlaying = false
+            updateNowPlayingInfo()
+        case .newDeviceAvailable, .override, .routeConfigurationChange:
+            // AirPlay or Bluetooth connected — re-activate session and continue
+            do {
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch {
+                print("Failed to reactivate audio session on route change: \(error)")
+            }
+            if wasPlayingBeforeRouteChange || isPlaying {
+                player?.play()
+                player?.rate = playbackSpeed
+                isPlaying = true
+                updateNowPlayingInfo()
+                wasPlayingBeforeRouteChange = false
+            }
+        default:
+            break
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix AirPlay to Apple TV by disabling external playback (auth headers can't be forwarded) and using `.longFormAudio` audio session policy
- Rewrite interruption/route change handlers to avoid side effects that lose chapters during AirPlay transitions
- Add "Show Chapter Progress" toggle in Settings — scopes player and mini player seek bar/time to current chapter
- Remove Share button from detail page overflow menu
- Bump build to 6 for TestFlight

## Test plan
- [ ] AirPlay to Apple TV plays audio, chapters preserved, disconnect doesn't crash
- [ ] Chapter progress toggle in Settings scopes seek bar and mini player time to chapter
- [ ] Share button removed from detail page overflow menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)