### PR TITLE
Remove delete from download button on detail page

### DIFF
--- a/Sappho/Presentation/Detail/AudiobookDetailView.swift
+++ b/Sappho/Presentation/Detail/AudiobookDetailView.swift
@@ -738,7 +738,7 @@ struct AudiobookDetailView: View {
         case .downloading:
             return "Double tap to cancel download"
         case .downloaded:
-            return "Double tap to remove download"
+            return "Downloaded for offline listening"
         case .failed:
             return "Double tap to retry download"
         }
@@ -751,8 +751,8 @@ struct AudiobookDetailView: View {
         case .downloading:
             downloadManager.cancelDownload(audiobookId: displayBook.id)
         case .downloaded:
-            // Show option to remove download
-            downloadManager.removeDownload(audiobookId: displayBook.id)
+            // No-op: deletion only available from Downloads screen
+            break
         }
     }
 

--- a/Sappho/Resources/Info.plist
+++ b/Sappho/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary
- Download button on detail page no longer allows deleting downloads
- Once downloaded, tapping the button is a no-op (shows green checkmark only)
- Deletion is only available from the Downloads screen in the dropdown menu
- Updated accessibility hint for downloaded state
- Build bump to 7

## Test plan
- [ ] Tap download button to start a download
- [ ] Verify downloaded state shows green checkmark
- [ ] Verify tapping checkmark does nothing (no removal)
- [ ] Verify deletion still works from Downloads screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)