### PR TITLE
Auto-refresh home screen and button layout fixes

### DIFF
--- a/Sappho/Presentation/Home/HomeView.swift
+++ b/Sappho/Presentation/Home/HomeView.swift
@@ -4,6 +4,7 @@ import Network
 struct HomeView: View {
     @Environment(\.sapphoAPI) private var api
     @Environment(AudioPlayerService.self) private var audioPlayer
+    @Environment(\.scenePhase) private var scenePhase
     @Binding var navigationPath: NavigationPath
 
     @State private var continueListening: [Audiobook] = []
@@ -142,6 +143,11 @@ struct HomeView: View {
         }
         .task {
             await loadData()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task { await loadData() }
+            }
         }
     }
 

--- a/Sappho/Resources/Info.plist
+++ b/Sappho/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary
- Home screen now auto-refreshes when the app returns to the foreground via scenePhase observer
- Previously data only loaded on initial appearance or manual pull-to-refresh
- Build bump to 9

## Test plan
- [ ] Open app, navigate to home screen
- [ ] Background the app, wait a few seconds, return — data should refresh
- [ ] Verify pull-to-refresh still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)