### PR TITLE
Code quality and architecture fixes (Phases 5-6)

### DIFF
--- a/Sappho/App/AppDelegate.swift
+++ b/Sappho/App/AppDelegate.swift
@@ -1,25 +1,13 @@
 import UIKit
-import AVFoundation
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        // Configure audio session for background playback
-        configureAudioSession()
-
+        // Audio session is configured by AudioPlayerService.setupAudioSession()
+        // which sets .playback category with .longFormAudio policy.
         return true
-    }
-
-    private func configureAudioSession() {
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playback, mode: .spokenAudio, options: [])
-            try session.setActive(true)
-        } catch {
-            print("Failed to configure audio session: \(error)")
-        }
     }
 
     // Handle background URL session events for downloads

--- a/Sappho/App/ServiceLocator.swift
+++ b/Sappho/App/ServiceLocator.swift
@@ -2,17 +2,50 @@ import Foundation
 
 /// Simple shared container so non-SwiftUI classes (e.g. CarPlaySceneDelegate)
 /// can access the shared service instances created by SapphoApp.
-final class ServiceLocator {
+///
+/// Thread safety: All access is serialized through a serial dispatch queue.
+/// Initialization must happen via `configure()` before accessing any properties.
+final class ServiceLocator: @unchecked Sendable {
     static let shared = ServiceLocator()
 
-    private(set) var api: SapphoAPI?
-    private(set) var audioPlayer: AudioPlayerService?
-    private(set) var authRepository: AuthRepository?
+    private let queue = DispatchQueue(label: "com.sappho.servicelocator")
+    private var _isConfigured = false
+    private var _api: SapphoAPI?
+    private var _audioPlayer: AudioPlayerService?
+    private var _authRepository: AuthRepository?
+
+    var isConfigured: Bool {
+        queue.sync { _isConfigured }
+    }
+
+    var api: SapphoAPI? {
+        queue.sync {
+            assert(_isConfigured, "ServiceLocator.configure() must be called before accessing services")
+            return _api
+        }
+    }
+
+    var audioPlayer: AudioPlayerService? {
+        queue.sync {
+            assert(_isConfigured, "ServiceLocator.configure() must be called before accessing services")
+            return _audioPlayer
+        }
+    }
+
+    var authRepository: AuthRepository? {
+        queue.sync {
+            assert(_isConfigured, "ServiceLocator.configure() must be called before accessing services")
+            return _authRepository
+        }
+    }
 
     func configure(api: SapphoAPI, audioPlayer: AudioPlayerService, authRepository: AuthRepository) {
-        self.api = api
-        self.audioPlayer = audioPlayer
-        self.authRepository = authRepository
+        queue.sync {
+            self._api = api
+            self._audioPlayer = audioPlayer
+            self._authRepository = authRepository
+            self._isConfigured = true
+        }
     }
 
     private init() {}

--- a/Sappho/Presentation/Components/Theme.swift
+++ b/Sappho/Presentation/Components/Theme.swift
@@ -70,12 +70,67 @@ extension Color {
 
 // MARK: - Typography
 extension Font {
+    // Display fonts - large prominent text
+    static let sapphoDisplayLarge = Font.system(size: 48, weight: .bold, design: .rounded)
+    static let sapphoDisplayMedium = Font.system(size: 40, weight: .bold, design: .rounded)
+    static let sapphoDisplaySmall = Font.system(size: 36, weight: .bold)
+
+    // Title fonts
     static let sapphoTitle = Font.system(size: 28, weight: .bold)
+    static let sapphoTitleMedium = Font.system(size: 24, weight: .bold)
+    static let sapphoTitleSmall = Font.system(size: 22, weight: .bold)
+
+    // Headline fonts
     static let sapphoHeadline = Font.system(size: 20, weight: .semibold)
+    static let sapphoHeadlineMedium = Font.system(size: 18, weight: .semibold)
+
+    // Subheadline fonts
     static let sapphoSubheadline = Font.system(size: 16, weight: .medium)
+    static let sapphoSubheadlineBold = Font.system(size: 16, weight: .bold)
+    static let sapphoSubheadlineRounded = Font.system(size: 16, weight: .bold, design: .rounded)
+
+    // Body fonts
     static let sapphoBody = Font.system(size: 15, weight: .regular)
+    static let sapphoBodyMedium = Font.system(size: 15, weight: .medium)
+    static let sapphoBodySemibold = Font.system(size: 15, weight: .semibold)
+
+    // Detail fonts
+    static let sapphoDetail = Font.system(size: 14, weight: .regular)
+    static let sapphoDetailMedium = Font.system(size: 14, weight: .medium)
+    static let sapphoDetailSemibold = Font.system(size: 14, weight: .semibold)
+
+    // Caption fonts
     static let sapphoCaption = Font.system(size: 13, weight: .regular)
+    static let sapphoCaptionMedium = Font.system(size: 13, weight: .medium)
+    static let sapphoCaptionSemibold = Font.system(size: 13, weight: .semibold)
+
+    // Small fonts
     static let sapphoSmall = Font.system(size: 11, weight: .regular)
+    static let sapphoSmallMedium = Font.system(size: 11, weight: .medium)
+    static let sapphoSmallBold = Font.system(size: 11, weight: .bold)
+
+    // Tiny fonts - badges, labels
+    static let sapphoTiny = Font.system(size: 10, weight: .regular)
+    static let sapphoTinyBold = Font.system(size: 10, weight: .bold)
+    static let sapphoTinySemibold = Font.system(size: 10, weight: .semibold)
+    static let sapphoMicro = Font.system(size: 8, weight: .regular)
+    static let sapphoTinyDetail = Font.system(size: 12, weight: .regular)
+
+    // Icon fonts - for SF Symbol sizing
+    static let sapphoIconXXLarge = Font.system(size: 48)
+    static let sapphoIconXLarge = Font.system(size: 40)
+    static let sapphoIconHuge = Font.system(size: 36)
+    static let sapphoIconLarge = Font.system(size: 32)
+    static let sapphoIconMedium = Font.system(size: 22)
+    static let sapphoIconSmall = Font.system(size: 20)
+    static let sapphoIconTiny = Font.system(size: 18)
+    static let sapphoIconMini = Font.system(size: 12)
+
+    // Player-specific fonts
+    static let sapphoPlayerSpeed = Font.system(size: 48, weight: .bold, design: .rounded)
+    static let sapphoPlayerTimerDisplay = Font.system(size: 40, weight: .bold, design: .rounded)
+    static let sapphoPlayerTimerLabel = Font.system(size: 20, weight: .semibold, design: .rounded)
+    static let sapphoPlayerPlayButton = Font.system(size: 28)
 }
 
 // MARK: - View Modifiers
@@ -134,7 +189,7 @@ struct ErrorView: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 48))
+                .font(.sapphoIconXXLarge)
                 .foregroundColor(.sapphoError)
 
             Text(message)
@@ -161,7 +216,7 @@ struct EmptyStateView: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: icon)
-                .font(.system(size: 48))
+                .font(.sapphoIconXXLarge)
                 .foregroundColor(.sapphoTextMuted)
 
             Text(title)

--- a/Sappho/Presentation/Detail/AudiobookDetailView.swift
+++ b/Sappho/Presentation/Detail/AudiobookDetailView.swift
@@ -242,7 +242,7 @@ struct AudiobookDetailView: View {
                         Task { await toggleFavorite() }
                     } label: {
                         Image(systemName: isFavorite ? "bookmark.fill" : "bookmark")
-                            .font(.system(size: 22, weight: .medium))
+                            .font(.sapphoTitleSmall)
                             .foregroundColor(isFavorite ? .sapphoPrimary : .white)
                             .frame(width: 40, height: 40)
                             .background(Color.black.opacity(0.5))
@@ -306,12 +306,12 @@ struct AudiobookDetailView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "star.fill")
                             .foregroundColor(.sapphoWarning)
-                            .font(.system(size: 15))
+                            .font(.sapphoBody)
                         Text(String(format: "%.1f", avg.average ?? 0))
-                            .font(.system(size: 15, weight: .medium))
+                            .font(.sapphoBodyMedium)
                             .foregroundColor(.sapphoTextHigh)
                         Text("(\(avg.count))")
-                            .font(.system(size: 13))
+                            .font(.sapphoCaption)
                             .foregroundColor(.sapphoTextMuted)
                     }
                 }
@@ -325,14 +325,14 @@ struct AudiobookDetailView: View {
                     HStack(spacing: 4) {
                         if userRating != nil {
                             Image(systemName: "star.fill")
-                                .font(.system(size: 14))
+                                .font(.sapphoDetail)
                                 .foregroundColor(.sapphoWarning)
                         } else {
                             Image(systemName: "star")
-                                .font(.system(size: 14))
+                                .font(.sapphoDetail)
                                 .foregroundColor(.sapphoTextMuted)
                             Text("Rate")
-                                .font(.system(size: 13))
+                                .font(.sapphoCaption)
                                 .foregroundColor(.sapphoTextMuted)
                         }
                     }
@@ -361,7 +361,7 @@ struct AudiobookDetailView: View {
                             }
                         } label: {
                             Image(systemName: star <= (userRating ?? 0) ? "star.fill" : "star")
-                                .font(.system(size: 32))
+                                .font(.sapphoIconLarge)
                                 .foregroundColor(star <= (userRating ?? 0) ? .sapphoWarning : .sapphoTextMuted.opacity(0.4))
                         }
                         .accessibilityLabel("Rate \(star) star\(star == 1 ? "" : "s")")
@@ -464,7 +464,7 @@ struct AudiobookDetailView: View {
                     HStack(spacing: 2) {
                         ForEach(1...5, id: \.self) { star in
                             Image(systemName: star <= rating ? "star.fill" : "star")
-                                .font(.system(size: 10))
+                                .font(.sapphoTiny)
                                 .foregroundColor(star <= rating ? .sapphoWarning : .sapphoTextMuted)
                         }
                     }
@@ -479,7 +479,7 @@ struct AudiobookDetailView: View {
 
             if let dateString = item.updatedAt ?? item.createdAt {
                 Text(relativeDate(from: dateString))
-                    .font(.system(size: 11))
+                    .font(.sapphoSmall)
                     .foregroundColor(.sapphoTextMuted)
             }
         }
@@ -523,7 +523,7 @@ struct AudiobookDetailView: View {
                 showMoreMenu = true
             } label: {
                 Image(systemName: "ellipsis")
-                    .font(.system(size: 20, weight: .medium))
+                    .font(.sapphoHeadline)
                     .foregroundColor(.sapphoTextHigh)
                     .frame(width: 48, height: 60)
                     .background(Color.sapphoSurface.opacity(0.5))
@@ -549,9 +549,9 @@ struct AudiobookDetailView: View {
             } label: {
                 HStack(spacing: 8) {
                     Image(systemName: isCurrentlyPlaying ? "pause.fill" : "play.fill")
-                        .font(.system(size: 22))
+                        .font(.sapphoIconMedium)
                     Text(isCurrentlyPlaying ? "Pause" : (hasProgress ? "Continue" : "Play"))
-                        .font(.system(size: 17, weight: .semibold))
+                        .font(.sapphoBodySemibold)
                 }
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
@@ -624,7 +624,7 @@ struct AudiobookDetailView: View {
                             let chapterIndex = chapters.firstIndex(where: { $0.startTime == chapter.startTime }) ?? 0
                             HStack(spacing: 6) {
                                 Image(systemName: "bookmark.fill")
-                                    .font(.system(size: 12))
+                                    .font(.sapphoIconMini)
                                     .foregroundColor(.sapphoPrimary)
                                 Text(chapter.title ?? "Chapter \(chapterIndex + 1)")
                                     .font(.sapphoSmall)
@@ -780,7 +780,7 @@ struct AudiobookDetailView: View {
         Button(action: action) {
             HStack(spacing: 14) {
                 Image(systemName: icon)
-                    .font(.system(size: 18, weight: .medium))
+                    .font(.sapphoHeadlineMedium)
                     .foregroundColor(color)
                     .frame(width: 40, height: 40)
                     .background(color.opacity(0.12))
@@ -788,17 +788,17 @@ struct AudiobookDetailView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.sapphoSubheadline)
                         .foregroundColor(.sapphoTextHigh)
                     Text(subtitle)
-                        .font(.system(size: 13))
+                        .font(.sapphoCaption)
                         .foregroundColor(.sapphoTextMuted)
                 }
 
                 Spacer()
 
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.sapphoCaptionSemibold)
                     .foregroundColor(.sapphoTextMuted.opacity(0.5))
             }
             .padding(.horizontal, 14)
@@ -828,7 +828,7 @@ struct AudiobookDetailView: View {
                         .font(.system(size: 12, weight: .bold))
                         .foregroundColor(.sapphoTextMuted)
                     Text("\(Int(progress * 100))%")
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.sapphoDetailSemibold)
                         .foregroundColor(.sapphoTextHigh)
                         .contentTransition(.numericText())
                 }
@@ -870,17 +870,17 @@ struct AudiobookDetailView: View {
         switch downloadState {
         case .notDownloaded:
             Image(systemName: "arrow.down.circle")
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.sapphoTextMuted)
         case .downloading:
             EmptyView()
         case .downloaded:
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.sapphoSuccess)
         case .failed:
             Image(systemName: "exclamationmark.circle")
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.sapphoError)
         }
     }
@@ -1093,13 +1093,13 @@ struct MetadataItem: View {
             if let onTap = onTap {
                 Button(action: onTap) {
                     Text(value)
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.sapphoSubheadline)
                         .foregroundColor(.sapphoPrimary)
                 }
                 .buttonStyle(.plain)
             } else {
                 Text(value)
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.sapphoSubheadline)
                     .foregroundColor(isLink ? .sapphoPrimary : .sapphoTextHigh)
             }
         }
@@ -1159,7 +1159,7 @@ struct AddToCollectionSheet: View {
 
                                     if collection.isPublic == 1 {
                                         Image(systemName: "globe")
-                                            .font(.system(size: 12))
+                                            .font(.sapphoIconMini)
                                             .foregroundColor(.sapphoTextMuted)
                                     }
                                 }

--- a/Sappho/Presentation/Home/HomeView.swift
+++ b/Sappho/Presentation/Home/HomeView.swift
@@ -28,7 +28,7 @@ struct HomeView: View {
                     if isOffline {
                         HStack(spacing: 8) {
                             Image(systemName: "wifi.slash")
-                                .font(.system(size: 14))
+                                .font(.sapphoDetail)
                             Text("No internet connection")
                                 .font(.sapphoCaption)
                             Spacer()

--- a/Sappho/Presentation/Home/MainView.swift
+++ b/Sappho/Presentation/Home/MainView.swift
@@ -86,16 +86,18 @@ struct MainView: View {
         }
         .overlay {
             if audioPlayer.currentAudiobook != nil {
-                PlayerView(showFullPlayer: Binding(
-                    get: { audioPlayer.showFullPlayer },
-                    set: { newValue in
-                        withAnimation(.spring(response: 0.35, dampingFraction: 0.86)) {
-                            audioPlayer.showFullPlayer = newValue
+                GeometryReader { geometry in
+                    PlayerView(showFullPlayer: Binding(
+                        get: { audioPlayer.showFullPlayer },
+                        set: { newValue in
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.86)) {
+                                audioPlayer.showFullPlayer = newValue
+                            }
                         }
-                    }
-                ))
-                    .offset(y: audioPlayer.showFullPlayer ? 0 : UIScreen.main.bounds.height)
-                    .zIndex(1)
+                    ))
+                    .offset(y: audioPlayer.showFullPlayer ? 0 : geometry.size.height + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom)
+                }
+                .zIndex(1)
             }
         }
         .sheet(isPresented: $showDownloads) {
@@ -204,7 +206,7 @@ struct MainView: View {
             }
         } label: {
             Image(systemName: icon)
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.sapphoTextMuted)
                 .frame(width: 48, height: 48)
                 .contentShape(Rectangle())
@@ -281,7 +283,7 @@ struct MainView: View {
                 .fill(Color.sapphoPrimary)
                 .frame(width: 40, height: 40)
             Text(userInitial)
-                .font(.system(size: 16, weight: .semibold))
+                .font(.sapphoSubheadline)
                 .foregroundColor(.white)
         }
     }
@@ -293,14 +295,14 @@ struct MainView: View {
             showNotificationPanel = true
         } label: {
             Image(systemName: "bell")
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.sapphoTextMuted)
                 .frame(width: 40, height: 40)
                 .contentShape(Rectangle())
                 .overlay(alignment: .topTrailing) {
                     if unreadCount > 0 {
                         Text("\(unreadCount)")
-                            .font(.system(size: 10, weight: .bold))
+                            .font(.sapphoTinyBold)
                             .foregroundColor(.white)
                             .frame(minWidth: 16, minHeight: 16)
                             .background(Color.red)
@@ -451,24 +453,24 @@ struct MiniPlayerView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         // Marquee title when playing, static when paused
                         if audioPlayer.isPlaying {
-                            MarqueeText(text: audiobook.title, font: .system(size: 13, weight: .semibold))
+                            MarqueeText(text: audiobook.title, font: .sapphoCaptionSemibold)
                                 .foregroundColor(.white)
                         } else {
                             Text(audiobook.title)
-                                .font(.system(size: 13, weight: .semibold))
+                                .font(.sapphoCaptionSemibold)
                                 .foregroundColor(.white)
                                 .lineLimit(1)
                         }
 
                         Text(audiobook.author ?? "Unknown Author")
-                            .font(.system(size: 11))
+                            .font(.sapphoSmall)
                             .foregroundColor(.sapphoTextMuted)
                             .lineLimit(1)
 
                         // Chapter name (if available)
                         if let chapter = audioPlayer.currentChapter, let chapterTitle = chapter.title {
                             Text(chapterTitle)
-                                .font(.system(size: 10))
+                                .font(.sapphoTiny)
                                 .foregroundColor(Color.sapphoPrimaryLight.opacity(0.8))
                                 .lineLimit(1)
                         } else {
@@ -501,7 +503,7 @@ struct MiniPlayerView: View {
                         audioPlayer.skipBackward(seconds: 10)
                     } label: {
                         Image(systemName: "gobackward.10")
-                            .font(.system(size: 18))
+                            .font(.sapphoIconTiny)
                             .foregroundColor(.sapphoTextMuted)
                     }
                     .frame(width: 36, height: 36)
@@ -518,7 +520,7 @@ struct MiniPlayerView: View {
                                 .scaleEffect(audioPlayer.isPlaying ? (playButtonGlowing ? 1.08 : 1.0) : 1.0)
                                 .shadow(color: playButtonColor.opacity(audioPlayer.isPlaying ? (playButtonGlowing ? 0.6 : 0.2) : 0), radius: audioPlayer.isPlaying ? 12 : 0)
                             Image(systemName: audioPlayer.isPlaying ? "pause.fill" : "play.fill")
-                                .font(.system(size: 22))
+                                .font(.sapphoIconMedium)
                                 .foregroundColor(.white)
                         }
                         .animation(.easeInOut(duration: 3.0).repeatForever(autoreverses: true), value: playButtonGlowing)
@@ -540,7 +542,7 @@ struct MiniPlayerView: View {
                         audioPlayer.skipForward(seconds: 10)
                     } label: {
                         Image(systemName: "goforward.10")
-                            .font(.system(size: 18))
+                            .font(.sapphoIconTiny)
                             .foregroundColor(.sapphoTextMuted)
                     }
                     .frame(width: 36, height: 36)
@@ -699,7 +701,7 @@ struct MiniPlayerTimeDisplay: View {
 
     var body: some View {
         Text("\(formatTime(displayPosition)) / \(formatTime(displayDuration))")
-            .font(.system(size: 10))
+            .font(.sapphoTiny)
             .foregroundColor(isPlaying
                 ? Color.sapphoPrimaryLight
                 : .sapphoTextMuted

--- a/Sappho/Presentation/Library/AuthorsListView.swift
+++ b/Sappho/Presentation/Library/AuthorsListView.swift
@@ -126,7 +126,7 @@ struct AuthorCard: View {
                     // Book count
                     HStack(spacing: 4) {
                         Image(systemName: "book.closed.fill")
-                            .font(.system(size: 12))
+                            .font(.sapphoIconMini)
                             .foregroundColor(.sapphoPrimary)
                         Text("\(authorInfo.bookCount)")
                             .font(.sapphoSmall)
@@ -136,7 +136,7 @@ struct AuthorCard: View {
                     // Duration
                     HStack(spacing: 4) {
                         Image(systemName: "clock")
-                            .font(.system(size: 12))
+                            .font(.sapphoIconMini)
                             .foregroundColor(.sapphoPrimary)
                         Text("\(totalDuration / 3600)h")
                             .font(.sapphoSmall)
@@ -147,7 +147,7 @@ struct AuthorCard: View {
                     if completedCount > 0 {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
-                                .font(.system(size: 12))
+                                .font(.sapphoIconMini)
                                 .foregroundColor(.sapphoSuccess)
                             Text("\(completedCount)/\(authorInfo.bookCount)")
                                 .font(.sapphoSmall)
@@ -160,7 +160,7 @@ struct AuthorCard: View {
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 14))
+                .font(.sapphoDetail)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(16)

--- a/Sappho/Presentation/Library/CollectionsListView.swift
+++ b/Sappho/Presentation/Library/CollectionsListView.swift
@@ -39,7 +39,7 @@ struct CollectionsListView: View {
                         } label: {
                             HStack {
                                 Image(systemName: "plus.circle.fill")
-                                    .font(.system(size: 20))
+                                    .font(.sapphoIconSmall)
                                     .foregroundColor(.sapphoPrimary)
                                 Text("Create New Collection")
                                     .font(.sapphoSubheadline)
@@ -153,7 +153,7 @@ struct CollectionCard: View {
                         .frame(width: 56, height: 56)
                         .overlay(
                             Image(systemName: "folder.fill")
-                                .font(.system(size: 20))
+                                .font(.sapphoIconSmall)
                                 .foregroundColor(.sapphoTextMuted)
                         )
                 }
@@ -170,7 +170,7 @@ struct CollectionCard: View {
 
                     if collection.isPublic == 1 {
                         Image(systemName: "globe")
-                            .font(.system(size: 12))
+                            .font(.sapphoIconMini)
                             .foregroundColor(.sapphoPrimary)
                     }
                 }
@@ -187,7 +187,7 @@ struct CollectionCard: View {
                 HStack(spacing: 12) {
                     HStack(spacing: 4) {
                         Image(systemName: "book.closed.fill")
-                            .font(.system(size: 12))
+                            .font(.sapphoIconMini)
                             .foregroundColor(.sapphoPrimary)
                         Text("\(collection.bookCount ?? 0)")
                             .font(.sapphoSmall)
@@ -197,7 +197,7 @@ struct CollectionCard: View {
                     if let creator = collection.creatorUsername, collection.isOwner != 1 {
                         HStack(spacing: 4) {
                             Image(systemName: "person.fill")
-                                .font(.system(size: 12))
+                                .font(.sapphoIconMini)
                                 .foregroundColor(.sapphoTextMuted)
                             Text(creator)
                                 .font(.sapphoSmall)
@@ -210,7 +210,7 @@ struct CollectionCard: View {
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 14))
+                .font(.sapphoDetail)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(12)

--- a/Sappho/Presentation/Library/FilteredBooksView.swift
+++ b/Sappho/Presentation/Library/FilteredBooksView.swift
@@ -190,7 +190,7 @@ struct StatItem: View {
     var body: some View {
         VStack(spacing: 4) {
             Image(systemName: icon)
-                .font(.system(size: 16))
+                .font(.sapphoSubheadline)
                 .foregroundColor(color)
 
             Text(value)
@@ -258,7 +258,7 @@ struct BookListItem: View {
                     if let duration = audiobook.duration {
                         HStack(spacing: 4) {
                             Image(systemName: "clock")
-                                .font(.system(size: 10))
+                                .font(.sapphoTiny)
                             Text(formatDuration(duration))
                                 .font(.sapphoSmall)
                         }
@@ -268,7 +268,7 @@ struct BookListItem: View {
                     if isCompleted {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
-                                .font(.system(size: 10))
+                                .font(.sapphoTiny)
                             Text("Completed")
                                 .font(.sapphoSmall)
                         }
@@ -276,7 +276,7 @@ struct BookListItem: View {
                     } else if let percent = progressPercent, percent > 0 {
                         HStack(spacing: 4) {
                             Image(systemName: "play.circle.fill")
-                                .font(.system(size: 10))
+                                .font(.sapphoTiny)
                             Text("\(Int(percent * 100))%")
                                 .font(.sapphoSmall)
                         }
@@ -287,7 +287,7 @@ struct BookListItem: View {
                     if let rating = audiobook.userRating {
                         HStack(spacing: 2) {
                             Image(systemName: "star.fill")
-                                .font(.system(size: 10))
+                                .font(.sapphoTiny)
                             Text(String(format: "%.0f", rating))
                                 .font(.sapphoSmall)
                         }
@@ -306,7 +306,7 @@ struct BookListItem: View {
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 14))
+                .font(.sapphoDetail)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(12)
@@ -347,7 +347,7 @@ struct SeriesRecapSheet: View {
                 } else if let error = errorMessage {
                     VStack(spacing: 16) {
                         Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: 40))
+                            .font(.sapphoDisplayMedium)
                             .foregroundColor(.sapphoWarning)
                         Text(error)
                             .font(.sapphoBody)
@@ -366,7 +366,7 @@ struct SeriesRecapSheet: View {
                             if recap.cached {
                                 HStack(spacing: 6) {
                                     Image(systemName: "clock.arrow.circlepath")
-                                        .font(.system(size: 12))
+                                        .font(.sapphoIconMini)
                                     Text("Cached recap")
                                         .font(.sapphoSmall)
                                 }

--- a/Sappho/Presentation/Library/GenresListView.swift
+++ b/Sappho/Presentation/Library/GenresListView.swift
@@ -120,7 +120,7 @@ struct GenreCard: View {
             // Icon and title
             HStack {
                 Image(systemName: iconName)
-                    .font(.system(size: 24))
+                    .font(.sapphoTitleMedium)
                     .foregroundColor(.white)
 
                 Spacer()

--- a/Sappho/Presentation/Library/LibraryView.swift
+++ b/Sappho/Presentation/Library/LibraryView.swift
@@ -106,7 +106,7 @@ struct LibraryView: View {
                 // Header
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Library")
-                        .font(.system(size: 28, weight: .bold))
+                        .font(.sapphoTitle)
                         .foregroundColor(.sapphoTextHigh)
 
                     if totalBooks > 0 {
@@ -258,7 +258,7 @@ struct CategoryCardLarge: View {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
-                        .font(.system(size: 22, weight: .bold))
+                        .font(.sapphoTitleSmall)
                         .foregroundColor(.white)
                     Text("\(count)")
                         .font(.system(size: 32, weight: .bold))
@@ -272,7 +272,7 @@ struct CategoryCardLarge: View {
                         .fill(Color.white.opacity(0.2))
                         .frame(width: 56, height: 56)
                     Image(systemName: icon)
-                        .font(.system(size: 28))
+                        .font(.sapphoTitle)
                         .foregroundColor(.white)
                 }
             }
@@ -309,7 +309,7 @@ struct CategoryCardMedium: View {
                         .fill(Color.white.opacity(0.2))
                         .frame(width: 48, height: 48)
                     Image(systemName: icon)
-                        .font(.system(size: 24))
+                        .font(.sapphoTitleMedium)
                         .foregroundColor(.white)
                 }
 
@@ -317,10 +317,10 @@ struct CategoryCardMedium: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("\(count)")
-                        .font(.system(size: 28, weight: .bold))
+                        .font(.sapphoTitle)
                         .foregroundColor(.white)
                     Text(title)
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.sapphoDetailMedium)
                         .foregroundColor(.white.opacity(0.9))
                 }
             }
@@ -357,17 +357,17 @@ struct CategoryCardWide: View {
                         .fill(Color.white.opacity(0.1))
                         .frame(width: 48, height: 48)
                     Image(systemName: icon)
-                        .font(.system(size: 24))
+                        .font(.sapphoTitleMedium)
                         .foregroundColor(.white)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
-                        .font(.system(size: 18, weight: .semibold))
+                        .font(.sapphoHeadlineMedium)
                         .foregroundColor(.white)
                     if let subtitle {
                         Text(subtitle)
-                            .font(.system(size: 13))
+                            .font(.sapphoCaption)
                             .foregroundColor(.white.opacity(0.7))
                     }
                 }
@@ -375,7 +375,7 @@ struct CategoryCardWide: View {
                 Spacer()
 
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 20))
+                    .font(.sapphoIconSmall)
                     .foregroundColor(.white.opacity(0.5))
             }
             .padding(.horizontal, 20)
@@ -493,13 +493,13 @@ struct AllBooksView: View {
                             } label: {
                                 HStack(spacing: 6) {
                                     Text("Sort")
-                                        .font(.system(size: 12))
+                                        .font(.sapphoIconMini)
                                         .foregroundColor(.sapphoTextMuted)
                                     Text(sortOption.rawValue)
-                                        .font(.system(size: 14))
+                                        .font(.sapphoDetail)
                                         .foregroundColor(.white)
                                     Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
-                                        .font(.system(size: 10))
+                                        .font(.sapphoTiny)
                                         .foregroundColor(.sapphoTextMuted)
                                 }
                                 .padding(.horizontal, 12)
@@ -526,13 +526,13 @@ struct AllBooksView: View {
                             } label: {
                                 HStack(spacing: 6) {
                                     Text("Show")
-                                        .font(.system(size: 12))
+                                        .font(.sapphoIconMini)
                                         .foregroundColor(.sapphoTextMuted)
                                     Text(filterOption.rawValue)
-                                        .font(.system(size: 14))
+                                        .font(.sapphoDetail)
                                         .foregroundColor(.white)
                                     Image(systemName: "chevron.down")
-                                        .font(.system(size: 10))
+                                        .font(.sapphoTiny)
                                         .foregroundColor(.sapphoTextMuted)
                                 }
                                 .padding(.horizontal, 12)
@@ -544,7 +544,7 @@ struct AllBooksView: View {
                             Spacer()
 
                             Text("\(sortedAudiobooks.count) books")
-                                .font(.system(size: 13))
+                                .font(.sapphoCaption)
                                 .foregroundColor(.sapphoTextMuted)
                         }
                         .padding(.horizontal, 16)
@@ -637,7 +637,7 @@ struct AllBooksGridItem: View {
                                 .fill(Color.sapphoSuccess)
                                 .frame(width: 20, height: 20)
                             Image(systemName: "checkmark")
-                                .font(.system(size: 10, weight: .bold))
+                                .font(.sapphoTinyBold)
                                 .foregroundColor(.white)
                         }
                         .padding(4)
@@ -652,10 +652,10 @@ struct AllBooksGridItem: View {
                         Spacer()
                         HStack(spacing: 2) {
                             Image(systemName: "star.fill")
-                                .font(.system(size: 8))
+                                .font(.sapphoMicro)
                                 .foregroundColor(.sapphoRating)
                             Text(String(format: "%.0f", rating))
-                                .font(.system(size: 10, weight: .semibold))
+                                .font(.sapphoTinySemibold)
                                 .foregroundColor(.white)
                         }
                         .padding(.horizontal, 4)

--- a/Sappho/Presentation/Library/SeriesListView.swift
+++ b/Sappho/Presentation/Library/SeriesListView.swift
@@ -142,7 +142,7 @@ struct SeriesCard: View {
                     // Book count
                     HStack(spacing: 4) {
                         Image(systemName: "book.closed.fill")
-                            .font(.system(size: 12))
+                            .font(.sapphoIconMini)
                             .foregroundColor(.sapphoPrimary)
                         Text("\(seriesInfo.bookCount)")
                             .font(.sapphoSmall)
@@ -152,7 +152,7 @@ struct SeriesCard: View {
                     // Duration
                     HStack(spacing: 4) {
                         Image(systemName: "clock")
-                            .font(.system(size: 12))
+                            .font(.sapphoIconMini)
                             .foregroundColor(.sapphoPrimary)
                         Text("\(totalDuration / 3600)h")
                             .font(.sapphoSmall)
@@ -163,7 +163,7 @@ struct SeriesCard: View {
                     if completedCount > 0 {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
-                                .font(.system(size: 12))
+                                .font(.sapphoIconMini)
                                 .foregroundColor(.sapphoSuccess)
                             Text("\(completedCount)/\(seriesInfo.bookCount)")
                                 .font(.sapphoSmall)
@@ -175,7 +175,7 @@ struct SeriesCard: View {
                     if let avgRating = seriesInfo.averageRating {
                         HStack(spacing: 4) {
                             Image(systemName: "star.fill")
-                                .font(.system(size: 12))
+                                .font(.sapphoIconMini)
                                 .foregroundColor(.sapphoWarning)
                             Text(String(format: "%.1f", avgRating))
                                 .font(.sapphoSmall)
@@ -188,7 +188,7 @@ struct SeriesCard: View {
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 14))
+                .font(.sapphoDetail)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(16)

--- a/Sappho/Presentation/Library/UploadView.swift
+++ b/Sappho/Presentation/Library/UploadView.swift
@@ -32,7 +32,7 @@ struct UploadView: View {
                     } label: {
                         HStack(spacing: 8) {
                             Image(systemName: "folder")
-                                .font(.system(size: 16))
+                                .font(.sapphoSubheadline)
                             Text("Select Files")
                                 .font(.sapphoSubheadline)
                         }
@@ -60,7 +60,7 @@ struct UploadView: View {
                         ForEach(selectedFiles.prefix(5), id: \.absoluteString) { url in
                             HStack(spacing: 8) {
                                 Image(systemName: "music.note")
-                                    .font(.system(size: 14))
+                                    .font(.sapphoDetail)
                                     .foregroundColor(.sapphoTextMuted)
                                 Text(url.lastPathComponent)
                                     .font(.sapphoSmall)

--- a/Sappho/Presentation/Notifications/NotificationPanel.swift
+++ b/Sappho/Presentation/Notifications/NotificationPanel.swift
@@ -21,7 +21,7 @@ struct NotificationPanel: View {
                 } else if let errorMessage {
                     VStack(spacing: 12) {
                         Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: 40))
+                            .font(.sapphoIconXLarge)
                             .foregroundColor(.sapphoTextMuted)
                         Text(errorMessage)
                             .font(.subheadline)
@@ -36,7 +36,7 @@ struct NotificationPanel: View {
                 } else if notifications.isEmpty {
                     VStack(spacing: 12) {
                         Image(systemName: "bell.slash")
-                            .font(.system(size: 40))
+                            .font(.sapphoIconXLarge)
                             .foregroundColor(.sapphoTextMuted)
                         Text("No notifications yet")
                             .font(.headline)
@@ -107,7 +107,7 @@ struct NotificationPanel: View {
 
             // Type icon
             Image(systemName: iconForType(notification.type))
-                .font(.system(size: 18))
+                .font(.sapphoIconTiny)
                 .foregroundColor(colorForType(notification.type))
                 .frame(width: 32, height: 32)
                 .background(colorForType(notification.type).opacity(0.15))

--- a/Sappho/Presentation/Player/PlayerView.swift
+++ b/Sappho/Presentation/Player/PlayerView.swift
@@ -37,7 +37,7 @@ struct PlayerView: View {
                             showFullPlayer = false
                         } label: {
                             Image(systemName: "chevron.down")
-                                .font(.system(size: 20, weight: .semibold))
+                                .font(.sapphoHeadline)
                                 .foregroundColor(.sapphoTextHigh)
                                 .frame(width: 44, height: 44)
                                 .contentShape(Rectangle())
@@ -190,7 +190,7 @@ struct PlayerView: View {
                                 jumpToPreviousChapter()
                             } label: {
                                 Image(systemName: "backward.end.fill")
-                                    .font(.system(size: 22))
+                                    .font(.sapphoIconMedium)
                                     .foregroundColor(hasChapters ? .sapphoTextHigh : Color.sapphoDisabled)
                             }
                             .disabled(!hasChapters)
@@ -205,7 +205,7 @@ struct PlayerView: View {
                                 audioPlayer.skipBackward(seconds: 10)
                             } label: {
                                 Image(systemName: "gobackward.10")
-                                    .font(.system(size: 32))
+                                    .font(.sapphoIconLarge)
                                     .foregroundColor(.sapphoTextHigh)
                             }
                             .frame(width: 52)
@@ -224,7 +224,7 @@ struct PlayerView: View {
                                             : Color.sapphoPrimaryLight)
                                         .frame(width: 72, height: 72)
                                     Image(systemName: audioPlayer.isPlaying ? "pause.fill" : "play.fill")
-                                        .font(.system(size: 28))
+                                        .font(.sapphoPlayerPlayButton)
                                         .foregroundColor(.white)
                                 }
                                 .scaleEffect(audioPlayer.isPlaying && isPulsing ? 1.08 : 1.0)
@@ -258,7 +258,7 @@ struct PlayerView: View {
                                 audioPlayer.skipForward(seconds: 10)
                             } label: {
                                 Image(systemName: "goforward.10")
-                                    .font(.system(size: 32))
+                                    .font(.sapphoIconLarge)
                                     .foregroundColor(.sapphoTextHigh)
                             }
                             .frame(width: 52)
@@ -271,7 +271,7 @@ struct PlayerView: View {
                                 jumpToNextChapter()
                             } label: {
                                 Image(systemName: "forward.end.fill")
-                                    .font(.system(size: 22))
+                                    .font(.sapphoIconMedium)
                                     .foregroundColor(hasChapters ? .sapphoTextHigh : Color.sapphoDisabled)
                             }
                             .disabled(!hasChapters)
@@ -290,10 +290,10 @@ struct PlayerView: View {
                             } label: {
                                 VStack(spacing: 6) {
                                     Image(systemName: "list.bullet")
-                                        .font(.system(size: 20))
+                                        .font(.sapphoIconSmall)
                                         .foregroundColor(hasChapters ? .sapphoPrimary : Color.sapphoDisabled)
                                     Text("Chapters")
-                                        .font(.system(size: 11))
+                                        .font(.sapphoSmall)
                                         .foregroundColor(hasChapters ? .sapphoTextHigh : Color.sapphoDisabled)
                                 }
                                 .frame(maxWidth: .infinity)
@@ -310,7 +310,7 @@ struct PlayerView: View {
                             } label: {
                                 VStack(spacing: 6) {
                                     Image(systemName: "speedometer")
-                                        .font(.system(size: 20))
+                                        .font(.sapphoIconSmall)
                                         .foregroundColor(.sapphoSecondary)
                                     Text(String(format: "%.2gx", audioPlayer.playbackSpeed))
                                         .font(.sapphoSmall)
@@ -330,21 +330,21 @@ struct PlayerView: View {
                                 VStack(spacing: 6) {
                                     if audioPlayer.sleepAtEndOfChapter {
                                         Image(systemName: "moon.zzz.fill")
-                                            .font(.system(size: 20))
+                                            .font(.sapphoIconSmall)
                                             .foregroundColor(.sapphoWarning)
                                         Text("Chapter")
                                             .font(.sapphoSmall)
                                             .foregroundColor(.sapphoWarning)
                                     } else if let remaining = audioPlayer.sleepTimerRemaining, remaining > 0 {
                                         Image(systemName: "moon.zzz.fill")
-                                            .font(.system(size: 20))
+                                            .font(.sapphoIconSmall)
                                             .foregroundColor(.sapphoWarning)
                                         Text(formatTime(remaining))
                                             .font(.sapphoSmall)
                                             .foregroundColor(.sapphoWarning)
                                     } else {
                                         Image(systemName: "moon.zzz")
-                                            .font(.system(size: 20))
+                                            .font(.sapphoIconSmall)
                                             .foregroundColor(.sapphoWarning)
                                         Text("Off")
                                             .font(.sapphoSmall)
@@ -520,7 +520,7 @@ struct SpeedPickerSheet: View {
 
             // Current speed display
             Text(displaySpeed)
-                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .font(.sapphoPlayerSpeed)
                 .foregroundColor(.sapphoTextHigh)
                 .contentTransition(.numericText())
 
@@ -591,7 +591,7 @@ struct SleepTimerSheet: View {
                 // Active timer display
                 VStack(spacing: 8) {
                     Text(formatTime(remaining))
-                        .font(.system(size: 40, weight: .bold, design: .rounded))
+                        .font(.sapphoPlayerTimerDisplay)
                         .foregroundColor(.sapphoWarning)
                     Text("remaining")
                         .font(.sapphoCaption)
@@ -616,10 +616,10 @@ struct SleepTimerSheet: View {
                 // End of chapter active
                 VStack(spacing: 8) {
                     Image(systemName: "moon.zzz.fill")
-                        .font(.system(size: 36))
+                        .font(.sapphoIconHuge)
                         .foregroundColor(.sapphoWarning)
                     Text("End of chapter")
-                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        .font(.sapphoPlayerTimerLabel)
                         .foregroundColor(.sapphoWarning)
                 }
 
@@ -746,7 +746,7 @@ struct ChaptersSheet: View {
                         HStack {
                             if isCurrent {
                                 Image(systemName: "speaker.wave.2.fill")
-                                    .font(.system(size: 12))
+                                    .font(.sapphoIconMini)
                                     .foregroundColor(.sapphoPrimary)
                                     .accessibilityHidden(true)
                             }

--- a/Sappho/Presentation/Profile/ProfileView.swift
+++ b/Sappho/Presentation/Profile/ProfileView.swift
@@ -133,7 +133,7 @@ struct ProfileView: View {
                                     .aspectRatio(contentMode: .fill)
                             } else {
                                 Text(avatarInitial)
-                                    .font(.system(size: 24, weight: .bold))
+                                    .font(.sapphoTitleMedium)
                                     .foregroundColor(.sapphoTextHigh)
                             }
                         }
@@ -144,7 +144,7 @@ struct ProfileView: View {
                 VStack {
                     Spacer()
                     Text("Edit")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.sapphoSmallMedium)
                         .foregroundColor(.sapphoTextHigh)
                         .frame(maxWidth: .infinity)
                         .frame(height: 20)
@@ -161,7 +161,7 @@ struct ProfileView: View {
             Button("Remove photo") {
                 Task { await deleteAvatar() }
             }
-            .font(.system(size: 11, weight: .medium))
+            .font(.sapphoSmallMedium)
             .foregroundColor(.sapphoTextMuted)
             .padding(.top, 4)
         } else {
@@ -170,13 +170,13 @@ struct ProfileView: View {
 
         // Display name
         Text(currentName)
-            .font(.system(size: 20, weight: .semibold))
+            .font(.sapphoHeadline)
             .foregroundColor(.sapphoTextHigh)
             .padding(.top, 8)
 
         // Member since
         Text(memberSinceText(user: user))
-            .font(.system(size: 13))
+            .font(.sapphoCaption)
             .foregroundColor(.sapphoTextMuted)
             .padding(.top, 2)
 
@@ -194,23 +194,23 @@ struct ProfileView: View {
             VStack(spacing: 2) {
                 HStack(alignment: .bottom, spacing: 0) {
                     Text("\(hours)")
-                        .font(.system(size: 20, weight: .semibold))
+                        .font(.sapphoHeadline)
                         .foregroundColor(.sapphoTextHigh)
                     Text("h")
-                        .font(.system(size: 13))
+                        .font(.sapphoCaption)
                         .foregroundColor(.sapphoTextMuted)
                         .padding(.leading, 1)
                     Spacer().frame(width: 4)
                     Text("\(minutes)")
-                        .font(.system(size: 20, weight: .semibold))
+                        .font(.sapphoHeadline)
                         .foregroundColor(.sapphoTextHigh)
                     Text("m")
-                        .font(.system(size: 13))
+                        .font(.sapphoCaption)
                         .foregroundColor(.sapphoTextMuted)
                         .padding(.leading, 1)
                 }
                 Text("listened")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.sapphoSmallMedium)
                     .foregroundColor(.sapphoTextMuted)
             }
             .frame(maxWidth: .infinity)
@@ -223,10 +223,10 @@ struct ProfileView: View {
             // Finished
             VStack(spacing: 2) {
                 Text("\(stats.booksCompleted)")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(.sapphoHeadline)
                     .foregroundColor(.sapphoTextHigh)
                 Text("finished")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.sapphoSmallMedium)
                     .foregroundColor(.sapphoTextMuted)
             }
             .frame(maxWidth: .infinity)
@@ -239,10 +239,10 @@ struct ProfileView: View {
             // In Progress
             VStack(spacing: 2) {
                 Text("\(stats.currentlyListening)")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(.sapphoHeadline)
                     .foregroundColor(.sapphoTextHigh)
                 Text("in progress")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.sapphoSmallMedium)
                     .foregroundColor(.sapphoTextMuted)
             }
             .frame(maxWidth: .infinity)
@@ -346,7 +346,7 @@ struct ProfileView: View {
                 Task { await saveProfile() }
             } label: {
                 Text(isSaving ? "Saving..." : "Save Changes")
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.sapphoDetailMedium)
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
@@ -359,7 +359,7 @@ struct ProfileView: View {
             // Save message
             if let message = saveMessage {
                 Text(message)
-                    .font(.system(size: 12))
+                    .font(.sapphoTinyDetail)
                     .foregroundColor(message.hasPrefix("Error") ? .sapphoError : .sapphoSuccess)
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
@@ -384,7 +384,7 @@ struct ProfileView: View {
                     withAnimation { showPasswordSection = true }
                 } label: {
                     Text("Change Password")
-                        .font(.system(size: 14))
+                        .font(.sapphoDetail)
                         .foregroundColor(.sapphoTextHigh)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
@@ -407,7 +407,7 @@ struct ProfileView: View {
 
                         if let error = passwordError {
                             Text(error)
-                                .font(.system(size: 12))
+                                .font(.sapphoTinyDetail)
                                 .foregroundColor(.sapphoError)
                         }
                     }
@@ -425,7 +425,7 @@ struct ProfileView: View {
                             }
                         } label: {
                             Text("Cancel")
-                                .font(.system(size: 14))
+                                .font(.sapphoDetail)
                                 .foregroundColor(.sapphoTextMuted)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 14)
@@ -440,7 +440,7 @@ struct ProfileView: View {
                             Task { await changePassword() }
                         } label: {
                             Text(isChangingPassword ? "Changing..." : "Change Password")
-                                .font(.system(size: 14, weight: .medium))
+                                .font(.sapphoDetailMedium)
                                 .foregroundColor(.white)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 14)
@@ -473,9 +473,9 @@ struct ProfileView: View {
             } label: {
                 HStack(spacing: 8) {
                     Image(systemName: "gearshape")
-                        .font(.system(size: 16))
+                        .font(.sapphoSubheadline)
                     Text("Playback Settings")
-                        .font(.system(size: 14))
+                        .font(.sapphoDetail)
                 }
                 .foregroundColor(.sapphoTextHigh)
                 .frame(maxWidth: .infinity)
@@ -505,11 +505,11 @@ struct ProfileView: View {
             VStack(spacing: 0) {
                 HStack {
                     Text("App Version")
-                        .font(.system(size: 14))
+                        .font(.sapphoDetail)
                         .foregroundColor(.sapphoTextMuted)
                     Spacer()
                     Text(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0")
-                        .font(.system(size: 14))
+                        .font(.sapphoDetail)
                         .foregroundColor(.sapphoTextHigh)
                 }
 
@@ -517,11 +517,11 @@ struct ProfileView: View {
                     Spacer().frame(height: 8)
                     HStack {
                         Text("Server Version")
-                            .font(.system(size: 14))
+                            .font(.sapphoDetail)
                             .foregroundColor(.sapphoTextMuted)
                         Spacer()
                         Text(version)
-                            .font(.system(size: 14))
+                            .font(.sapphoDetail)
                             .foregroundColor(.sapphoTextHigh)
                     }
                 }
@@ -539,9 +539,9 @@ struct ProfileView: View {
             } label: {
                 HStack(spacing: 8) {
                     Image(systemName: "rectangle.portrait.and.arrow.right")
-                        .font(.system(size: 16))
+                        .font(.sapphoSubheadline)
                     Text("Logout")
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.sapphoDetailMedium)
                 }
                 .foregroundColor(.sapphoError)
                 .frame(maxWidth: .infinity)
@@ -564,7 +564,7 @@ struct ProfileView: View {
 
     private func outlinedTextField(_ label: String, text: Binding<String>) -> some View {
         TextField(label, text: text)
-            .font(.system(size: 14))
+            .font(.sapphoDetail)
             .foregroundStyle(Color.sapphoTextHigh)
             .padding(12)
             .background(Color.clear)
@@ -576,7 +576,7 @@ struct ProfileView: View {
 
     private func outlinedSecureField(_ label: String, text: Binding<String>) -> some View {
         SecureField(label, text: text)
-            .font(.system(size: 14))
+            .font(.sapphoDetail)
             .foregroundStyle(Color.sapphoTextHigh)
             .padding(12)
             .background(Color.clear)
@@ -919,7 +919,7 @@ struct DownloadedBookRow: View {
                 if let duration = audiobook.duration {
                     HStack(spacing: 4) {
                         Image(systemName: "clock")
-                            .font(.system(size: 10))
+                            .font(.sapphoTiny)
                         Text(formatDuration(duration))
                             .font(.sapphoSmall)
                     }
@@ -928,7 +928,7 @@ struct DownloadedBookRow: View {
 
                 HStack(spacing: 4) {
                     Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 10))
+                        .font(.sapphoTiny)
                     Text("Downloaded")
                         .font(.sapphoSmall)
                 }
@@ -942,14 +942,14 @@ struct DownloadedBookRow: View {
                 onDelete()
             } label: {
                 Image(systemName: "trash")
-                    .font(.system(size: 16))
+                    .font(.sapphoSubheadline)
                     .foregroundColor(.sapphoError)
             }
             .buttonStyle(.plain)
             .padding(8)
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 14))
+                .font(.sapphoDetail)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(12)

--- a/Sappho/Presentation/Profile/ReadingListView.swift
+++ b/Sappho/Presentation/Profile/ReadingListView.swift
@@ -163,7 +163,7 @@ struct ReadingListRow: View {
         HStack(spacing: 12) {
             // Position number
             Text("\(position)")
-                .font(.system(size: 16, weight: .bold, design: .rounded))
+                .font(.sapphoSubheadlineRounded)
                 .foregroundColor(.sapphoPrimary)
                 .frame(width: 28)
 

--- a/Sappho/Presentation/Search/SearchView.swift
+++ b/Sappho/Presentation/Search/SearchView.swift
@@ -45,7 +45,7 @@ struct SearchView: View {
                                 seriesResults = []
                                 authorResults = []
                             }
-                            .font(.system(size: 14, weight: .medium))
+                            .font(.sapphoDetailMedium)
                             .foregroundColor(.sapphoPrimary)
                         }
                     } else if !hasResults && searchText.isEmpty {
@@ -168,11 +168,11 @@ struct SearchBar: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 18))
+                .font(.sapphoIconTiny)
                 .foregroundColor(.sapphoTextMuted)
 
             TextField("Search books, series, authors...", text: $text)
-                .font(.system(size: 16))
+                .font(.sapphoSubheadline)
                 .foregroundColor(.sapphoTextHigh)
                 .focused($isFocused)
                 .autocorrectionDisabled()
@@ -183,7 +183,7 @@ struct SearchBar: View {
                     onClear()
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 18))
+                        .font(.sapphoIconTiny)
                         .foregroundColor(.sapphoTextMuted)
                 }
             }
@@ -292,7 +292,7 @@ struct BookSearchResult: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(audiobook.title)
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.sapphoDetailMedium)
                     .foregroundColor(.sapphoTextHigh)
                     .lineLimit(1)
 
@@ -305,7 +305,7 @@ struct BookSearchResult: View {
                         Text(series)
                     }
                 }
-                .font(.system(size: 12))
+                .font(.sapphoIconMini)
                 .foregroundColor(.sapphoTextMuted)
                 .lineLimit(1)
             }
@@ -313,7 +313,7 @@ struct BookSearchResult: View {
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 12))
+                .font(.sapphoIconMini)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(8)
@@ -329,21 +329,21 @@ struct SeriesSearchResult: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: "books.vertical.fill")
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.white)
                 .frame(width: 48, height: 48)
                 .background(Color.sapphoBorder)
                 .cornerRadius(6)
 
             Text(series.series)
-                .font(.system(size: 14, weight: .medium))
+                .font(.sapphoDetailMedium)
                 .foregroundColor(.sapphoTextHigh)
                 .lineLimit(1)
 
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 12))
+                .font(.sapphoIconMini)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(8)
@@ -359,21 +359,21 @@ struct AuthorSearchResult: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: "person.fill")
-                .font(.system(size: 20))
+                .font(.sapphoIconSmall)
                 .foregroundColor(.white)
                 .frame(width: 48, height: 48)
                 .background(Color.sapphoBorder)
                 .cornerRadius(6)
 
             Text(author.author)
-                .font(.system(size: 14, weight: .medium))
+                .font(.sapphoDetailMedium)
                 .foregroundColor(.sapphoTextHigh)
                 .lineLimit(1)
 
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 12))
+                .font(.sapphoIconMini)
                 .foregroundColor(.sapphoTextMuted)
         }
         .padding(8)

--- a/Sappho/Resources/Info.plist
+++ b/Sappho/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Sappho/Service/DownloadManager.swift
+++ b/Sappho/Service/DownloadManager.swift
@@ -99,8 +99,40 @@ struct CachedChapter: Codable {
     }
 }
 
+// MARK: - DownloadManaging Protocol
+
+/// Protocol for download management, enabling testability via dependency injection.
+/// In production, use `DownloadManager.shared`. In tests, provide a mock conforming to this protocol.
+protocol DownloadManaging {
+    var downloads: [Int: DownloadState] { get }
+    var cachedMeta: [Int: DownloadedBookMeta] { get }
+    func configure(api: SapphoAPI)
+    func download(audiobook: Audiobook)
+    func cancelDownload(audiobookId: Int)
+    func removeDownload(audiobookId: Int)
+    func localURL(for audiobookId: Int) -> URL?
+    func isDownloaded(_ audiobookId: Int) -> Bool
+    func downloadProgress(for audiobookId: Int) -> Double?
+    func updatePosition(audiobookId: Int, position: Int)
+    func cacheChapters(audiobookId: Int, chapters: [Chapter])
+    func downloadedAudiobooks() -> [Audiobook]
+    func totalDownloadSize() -> Int64
+    func clearAllDownloads()
+}
+
+// MARK: - DownloadManager
+
+/// Manages audiobook downloads with background URL session support.
+///
+/// This class uses the singleton pattern (`DownloadManager.shared`) because:
+/// 1. It must handle background URL session delegate callbacks from the system
+/// 2. `AppDelegate` must forward background session events to the same instance
+/// 3. `URLSession` background sessions require a single delegate for the app lifetime
+///
+/// For testability, code that depends on download functionality should accept
+/// a `DownloadManaging` protocol rather than referencing `DownloadManager.shared` directly.
 @Observable
-class DownloadManager: NSObject {
+class DownloadManager: NSObject, DownloadManaging {
     static let shared = DownloadManager()
 
     var downloads: [Int: DownloadState] = [:]


### PR DESCRIPTION
## Summary
- Replace ~150 hardcoded `.system(size:)` fonts with theme typography tokens (#52)
- Remove duplicate audio session setup from AppDelegate (#51)
- Replace deprecated `UIScreen.main` with `GeometryReader` (#50)
- Add thread safety to ServiceLocator (#53)
- Add `DownloadManaging` protocol for testability (#54)

Continuation of audit Phase 5-6 work (replaces auto-closed #56).

## Test plan
- [x] iOS build succeeds
- [ ] Verify fonts render correctly across all views
- [ ] Verify player overlay animation still works with GeometryReader

🤖 Generated with [Claude Code](https://claude.com/claude-code)