### PR TITLE
Fix speed slider precision and persist selected speed

### DIFF
--- a/Sappho/Presentation/Player/PlayerView.swift
+++ b/Sappho/Presentation/Player/PlayerView.swift
@@ -389,7 +389,7 @@ struct PlayerView: View {
                 SpeedPickerSheet(currentSpeed: audioPlayer.playbackSpeed) { speed in
                     audioPlayer.setPlaybackSpeed(speed)
                 }
-                .presentationDetents([.height(300)])
+                .presentationDetents([.height(400)])
             }
             .sheet(isPresented: $showSleepTimer) {
                 SleepTimerSheet(
@@ -488,6 +488,8 @@ struct SpeedPickerSheet: View {
     let currentSpeed: Float
     let onSelect: (Float) -> Void
 
+    private let presetSpeeds: [Float] = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
+
     @Environment(\.dismiss) private var dismiss
 
     @State private var speed: Float
@@ -502,12 +504,12 @@ struct SpeedPickerSheet: View {
         if speed == Float(Int(speed)) {
             return String(format: "%.0fx", speed)
         } else {
-            return String(format: "%.2gx", speed)
+            return String(format: "%.1fx", speed)
         }
     }
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: 20) {
             // Handle
             Capsule()
                 .fill(Color.sapphoTextMuted.opacity(0.4))
@@ -524,12 +526,33 @@ struct SpeedPickerSheet: View {
                 .foregroundColor(.sapphoTextHigh)
                 .contentTransition(.numericText())
 
-            // Slider
+            // Preset speed buttons
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 5), spacing: 8) {
+                ForEach(presetSpeeds, id: \.self) { preset in
+                    Button {
+                        speed = preset
+                        onSelect(preset)
+                    } label: {
+                        Text(preset == Float(Int(preset)) ? String(format: "%.0fx", preset) : String(format: "%.2gx", preset))
+                            .font(.sapphoCaptionSemibold)
+                            .foregroundColor(abs(speed - preset) < 0.01 ? .white : .sapphoTextHigh)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(abs(speed - preset) < 0.01 ? Color.sapphoPrimary : Color.sapphoSurfaceElevated)
+                            )
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+
+            // Fine-tune slider
             VStack(spacing: 8) {
                 Slider(
                     value: $speed,
                     in: 0.5...3.0,
-                    step: 0.05
+                    step: 0.1
                 ) {
                     Text("Speed")
                 } onEditingChanged: { editing in

--- a/Sappho/Resources/Info.plist
+++ b/Sappho/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Sappho/Service/AudioPlayerService.swift
+++ b/Sappho/Service/AudioPlayerService.swift
@@ -33,11 +33,16 @@ class AudioPlayerService: NSObject {
     private static let lastAudiobookIdKey = "lastPlayedAudiobookId"
     private static let lastPositionKey = "lastPlayedPosition"
     private static let pendingSyncKey = "pendingProgressSync"
+    private static let playbackSpeedKey = "playbackSpeed"
 
     // MARK: - Initialization
 
     override init() {
         super.init()
+        let savedSpeed = UserDefaults.standard.float(forKey: Self.playbackSpeedKey)
+        if savedSpeed > 0 {
+            playbackSpeed = savedSpeed
+        }
         setupAudioSession()
         setupRemoteCommands()
         setupInterruptionHandling()
@@ -280,6 +285,7 @@ class AudioPlayerService: NSObject {
 
     func setPlaybackSpeed(_ speed: Float) {
         playbackSpeed = speed
+        UserDefaults.standard.set(speed, forKey: Self.playbackSpeedKey)
         if isPlaying {
             player?.rate = speed
         }


### PR DESCRIPTION
## Summary
- Add preset speed buttons (0.5x, 0.75x, 1x, 1.25x, 1.5x, 1.75x, 2x, 2.5x, 3x) for quick selection
- Change slider step from 0.05 to 0.1 for easier fine-tuning
- Persist playback speed to UserDefaults — survives app close/reopen
- Fix display format to show consistent 1 decimal place

Fixes user report: "speed slider is too difficult to get to 1.3 vs .2 or .4 and doesn't retain selected speed after closing and reopening"

## Test plan
- [ ] Open speed picker — preset buttons appear in grid
- [ ] Tap 1.5x preset — highlights blue, speed changes immediately
- [ ] Use slider — snaps to 0.1 increments (1.0, 1.1, 1.2, 1.3...)
- [ ] Set speed to 1.3x, close app, reopen — speed should still be 1.3x
- [ ] Verify CarPlay speed cycling still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)