### PR TITLE
fix: CarPlay playback silently fails if phone screen never wakes

### DIFF
--- a/Sappho/App/SapphoApp.swift
+++ b/Sappho/App/SapphoApp.swift
@@ -15,6 +15,17 @@ struct SapphoApp: App {
         _api = State(initialValue: apiInstance)
         _audioPlayer = State(initialValue: playerInstance)
 
+        // Configure the player's API reference eagerly so it's ready
+        // before any caller (including CarPlay's didConnect, which can
+        // fire before the SwiftUI view appears) tries to stream audio.
+        // Previously this lived in the view's .task modifier, which
+        // only runs when the SwiftUI view renders its first frame —
+        // if the phone screen is off and CarPlay is the only active
+        // scene, .task never fires and playBook() silently fails
+        // because audioPlayer.api is nil.
+        playerInstance.configure(api: apiInstance)
+        DownloadManager.shared.configure(api: apiInstance)
+
         // Populate ServiceLocator so non-SwiftUI classes (e.g. CarPlaySceneDelegate) can access services
         ServiceLocator.shared.configure(api: apiInstance, audioPlayer: playerInstance, authRepository: repo)
     }
@@ -29,8 +40,9 @@ struct SapphoApp: App {
                 .environment(\.sapphoAPI, api)
                 .preferredColorScheme(.dark)
                 .task {
-                    audioPlayer.configure(api: api)
-                    DownloadManager.shared.configure(api: api)
+                    // configure(api:) already ran in init() so CarPlay
+                    // has access from the start. Only restoreLastPlayed
+                    // needs to be async and tied to the view lifecycle.
                     if authRepository.isAuthenticated {
                         await audioPlayer.restoreLastPlayed()
                     }


### PR DESCRIPTION
## Bug

User reported: select a book in CarPlay → Now Playing screen appears → nothing plays.

## Root cause

`AudioPlayerService.configure(api:)` lived in the SwiftUI `.task` modifier, which only fires when the **view renders its first frame**. If the phone screen stays off and CarPlay is the only active scene (common when driving), `.task` never runs. The player's internal `api` property stays nil, so `api?.streamURL(for:)` returns nil, and `play()` bails at the guard clause without any visible error.

## Fix

Moved `configure(api:)` and `DownloadManager.configure(api:)` from `.task` to `init()`, right alongside `ServiceLocator.configure()`. The player now has a valid API reference from app launch — before any scene (including CarPlay) can request playback.

Only `restoreLastPlayed()` remains in `.task` since it's genuinely async and tied to the view lifecycle.

## Test plan

- [x] `xcodebuild -scheme Sappho -destination 'generic/platform=iOS' build` — clean
- [ ] Connect CarPlay with phone screen off → select a book → audio should play + Now Playing should show transport controls
- [ ] Normal (non-CarPlay) playback still works
- [ ] App restart → last-played book still restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)