### PR TITLE
fix: show actual server error messages instead of raw HTTP codes

### DIFF
--- a/Sappho/Data/Remote/SapphoAPI.swift
+++ b/Sappho/Data/Remote/SapphoAPI.swift
@@ -87,7 +87,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
 
@@ -148,7 +148,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
     }
@@ -182,7 +182,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
 
@@ -401,7 +401,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
     }
@@ -619,7 +619,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
 
@@ -654,6 +654,13 @@ class SapphoAPI {
 private struct ErrorResponse: Codable {
     let message: String?
     let error: String?
+
+    /// The Sappho server inconsistently uses either `error` or `message`
+    /// for the human-readable text depending on the endpoint. This getter
+    /// returns whichever one is populated so callers don't have to guess.
+    var displayMessage: String? {
+        error ?? message
+    }
 }
 
 private struct LoginRequest: Codable {


### PR DESCRIPTION
Ayane got locked out with a 429 and the app showed \"HTTP error 429\" instead of the server's actual message \"Too many login attempts. Please try again in 15 minutes.\"

Root cause: \`ErrorResponse\` struct has both \`message\` and \`error\` fields, but all 5 call sites only read \`.message\`. The Sappho server uses \`error\` for error text, so \`.message\` was always nil.

Fix: added \`displayMessage\` computed property (\`error ?? message\`) and updated all 5 call sites. Every server error now surfaces its real text.

Separately, also added a 429 handler to the Android app's LoginViewModel (in the sappho-android repo, not this PR).

## Test plan
- [x] \`xcodebuild build\` clean
- [ ] Attempt login with wrong password 5+ times → should show \"Too many login attempts\" not \"HTTP error 429\"