### PR TITLE
fix: preserve server URL and username when session expires

### DIFF
--- a/Sappho/Data/Remote/SapphoAPI.swift
+++ b/Sappho/Data/Remote/SapphoAPI.swift
@@ -87,7 +87,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
 
@@ -148,7 +148,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
     }
@@ -182,7 +182,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
 
@@ -401,7 +401,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
     }
@@ -619,7 +619,7 @@ class SapphoAPI {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+            let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).displayMessage
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: message)
         }
 
@@ -654,6 +654,13 @@ class SapphoAPI {
 private struct ErrorResponse: Codable {
     let message: String?
     let error: String?
+
+    /// The Sappho server inconsistently uses either `error` or `message`
+    /// for the human-readable text depending on the endpoint. This getter
+    /// returns whichever one is populated so callers don't have to guess.
+    var displayMessage: String? {
+        error ?? message
+    }
 }
 
 private struct LoginRequest: Codable {

--- a/Sappho/Data/Remote/SapphoAPI.swift
+++ b/Sappho/Data/Remote/SapphoAPI.swift
@@ -82,7 +82,7 @@ class SapphoAPI {
         }
 
         if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            await MainActor.run { authRepository.clear() }
+            await MainActor.run { authRepository.clearToken() }
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: "Session expired. Please log in again.")
         }
 
@@ -143,7 +143,7 @@ class SapphoAPI {
         }
 
         if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            await MainActor.run { authRepository.clear() }
+            await MainActor.run { authRepository.clearToken() }
             throw APIError.httpError(statusCode: httpResponse.statusCode, message: "Session expired. Please log in again.")
         }
 

--- a/Sappho/Data/Repository/AuthRepository.swift
+++ b/Sappho/Data/Repository/AuthRepository.swift
@@ -96,6 +96,16 @@ class AuthRepository {
         }
     }
 
+    /// Clear only the auth token (called on 401 — session expired).
+    /// Preserves server URL and user info so the login screen can
+    /// pre-fill them instead of making the user re-enter everything.
+    func clearToken() {
+        token = nil
+        keychain.delete("authToken")
+    }
+
+    /// Full logout — wipes everything. Called when the user explicitly
+    /// logs out from the settings screen.
     func clear() {
         serverURL = nil
         token = nil

--- a/Sappho/Presentation/Login/LoginView.swift
+++ b/Sappho/Presentation/Login/LoginView.swift
@@ -135,9 +135,14 @@ struct LoginView: View {
         }
         .background(Color.sapphoBackground)
         .onAppear {
-            // Pre-fill server URL if previously stored
+            // Pre-fill server URL and username from the last session so
+            // a token expiry (401 → clearToken) only requires re-entering
+            // the password, not everything from scratch.
             if let stored = authRepository.serverURL {
                 serverURL = stored.absoluteString
+            }
+            if let user = authRepository.currentLoginUser {
+                username = user.username
             }
         }
     }


### PR DESCRIPTION
Token expiry was wiping everything. Now only clears the token — login screen pre-fills server URL and username so you just re-enter your password.