### PR TITLE
feat: add Remove Download to detail overflow menu

### DIFF
--- a/Sappho/Presentation/Detail/AudiobookDetailView.swift
+++ b/Sappho/Presentation/Detail/AudiobookDetailView.swift
@@ -48,6 +48,7 @@ struct AudiobookDetailView: View {
     // Admin features
     @State private var showEditSheet = false
     @State private var showDeleteConfirm = false
+    @State private var showRemoveDownloadConfirm = false
     @State private var showChapterEditor = false
     @State private var isRefreshing = false
     @State private var isConverting = false
@@ -166,6 +167,14 @@ struct AudiobookDetailView: View {
         } message: {
             Text("Are you sure you want to delete \"\(displayBook.title)\"? This cannot be undone.")
         }
+        .alert("Remove Download", isPresented: $showRemoveDownloadConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Remove", role: .destructive) {
+                downloadManager.removeDownload(audiobookId: displayBook.id)
+            }
+        } message: {
+            Text("Remove \"\(displayBook.title)\" from downloads? This will only delete the local file — your listening progress on the server will not be affected.")
+        }
         .sheet(isPresented: $showChaptersSheet) {
             ChaptersSheet(
                 chapters: chapters,
@@ -250,6 +259,18 @@ struct AudiobookDetailView: View {
                         }
                     }
 
+                    if case .downloaded = downloadState {
+                        moreMenuItem(
+                            icon: "trash",
+                            title: "Remove Download",
+                            subtitle: "Delete the local file",
+                            color: .sapphoError
+                        ) {
+                            showMoreMenu = false
+                            showRemoveDownloadConfirm = true
+                        }
+                    }
+
                     // Admin-only features
                     if authRepository.isAdmin {
                         Divider().background(Color.sapphoTextMuted.opacity(0.3)).padding(.vertical, 8)
@@ -306,7 +327,11 @@ struct AudiobookDetailView: View {
             }
             .frame(maxWidth: .infinity)
             .background(Color.sapphoSurface)
-            .presentationDetents([.fraction(authRepository.isAdmin ? 0.75 : (chapters.isEmpty ? 0.38 : 0.45))])
+            .presentationDetents([.fraction({
+                let base = authRepository.isAdmin ? 0.75 : (chapters.isEmpty ? 0.38 : 0.45)
+                let isDownloaded: Bool = { if case .downloaded = downloadState { return true } else { return false } }()
+                return base + (isDownloaded ? 0.05 : 0.0)
+            }())])
             .presentationDragIndicator(.hidden)
             .presentationCornerRadius(24)
         }


### PR DESCRIPTION
## Summary
- Adds a "Remove Download" item to the audiobook detail overflow sheet, visible only when the book is currently downloaded.
- Native iOS confirmation alert; on confirm, calls the existing `DownloadManager.removeDownload(audiobookId:)`. Server-side listening progress is unaffected.
- Adjusts the sheet's `presentationDetents` so the new row is not clipped.
- Pairs with the Android change in mondominator/sappho-android#263.

## Test plan
- [x] `xcodebuild build` succeeds (`** BUILD SUCCEEDED **` against `generic/platform=iOS`)
- [ ] Menu item appears on a downloaded book; hidden when not downloaded; hidden during active download
- [ ] Confirmation alert shows the configured copy with the book title; **Remove** deletes the local file
- [ ] **Cancel** preserves the download
- [ ] Sheet detent fits the new row in admin and non-admin views

## Spec
- Design: `sapphoapp/docs/superpowers/specs/2026-04-30-remove-download-overflow-design.md`
- Plan: `sapphoapp/docs/superpowers/plans/2026-04-30-remove-download-overflow.md`

## Notes
- Pre-existing test target build failure (`SapphoTests`/`SapphoUITests` missing `INFOPLIST_FILE`) is unrelated to this change and is on `main` already; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)