### PR TITLE
chore: enable Info.plist generation for test targets

### DIFF
--- a/Sappho.xcodeproj/project.pbxproj
+++ b/Sappho.xcodeproj/project.pbxproj
@@ -646,6 +646,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S6WU9SVVDW;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -664,6 +665,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S6WU9SVVDW;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -759,6 +761,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S6WU9SVVDW;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -797,6 +800,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S6WU9SVVDW;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- Adds `GENERATE_INFOPLIST_FILE = YES` to all four test build configs (`SapphoTests` Debug/Release, `SapphoUITests` Debug/Release).
- Without this, the test targets had no Info.plist source and no auto-generation, so `xcodebuild test` failed on every commit on `main` with: `the target does not have an Info.plist file and one is not being generated automatically`.

## Verification
- `xcodebuild test -project Sappho.xcodeproj -scheme Sappho -destination 'platform=iOS Simulator,name=iPhone 16'` → `** TEST SUCCEEDED **`
- Both `SapphoTests` (TimeFormattingTests, etc.) and `SapphoUITests` (testLaunch) now run cleanly.

## Why
Surfaced while smoke-testing #82 — was a pre-existing breakage on `main` that prevented running iOS unit tests at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)