### PR TITLE
chore: bump build to 35 for TestFlight

### DIFF
--- a/Sappho/Resources/Info.plist
+++ b/Sappho/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>34</string>
+	<string>35</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary
- Bumps `CFBundleVersion` 34 → 35 so the next TestFlight upload is accepted.
- Includes the Remove Download overflow action (#82) and the test-target Info.plist generation fix (#83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)